### PR TITLE
Handle bare `ClassVar` type qualifiers, rename `INFERRED` sentinel

### DIFF
--- a/docs/api/introspection.md
+++ b/docs/api/introspection.md
@@ -9,6 +9,5 @@
         - AnnotationSource
         - Qualifier
         - InspectedAnnotation
-        - INFERRED
-        - InferredType
+        - UNKNOWN
         - ForbiddenQualifier

--- a/tests/introspection/test_inspect_annotation.py
+++ b/tests/introspection/test_inspect_annotation.py
@@ -6,7 +6,13 @@ from typing import Any, Literal
 import pytest
 import typing_extensions as t_e
 
-from typing_inspection.introspection import INFERRED, AnnotationSource, ForbiddenQualifier, inspect_annotation
+from typing_inspection.introspection import UNKNOWN, AnnotationSource, ForbiddenQualifier, inspect_annotation
+
+
+def test_unknown_repr() -> None:
+    assert str(UNKNOWN) == 'UNKNOWN'
+    assert repr(UNKNOWN) == '<UNKNOWN>'
+
 
 _all_qualifiers: list[Any] = [
     t_e.ClassVar[int],
@@ -51,14 +57,30 @@ def test_annotation_source_invalid_qualifiers(source: AnnotationSource, annotati
             inspect_annotation(annotation, annotation_source=source)
 
 
-def test_bare_final_qualifier() -> None:
+def test_final_bare_final_qualifier() -> None:
     result = inspect_annotation(
         t.Final,
         annotation_source=AnnotationSource.ANY,
     )
 
     assert result.qualifiers == {'final'}
-    assert result.type is INFERRED
+    assert result.type is UNKNOWN
+
+    with pytest.raises(ForbiddenQualifier):
+        inspect_annotation(t.Final, annotation_source=AnnotationSource.BARE)
+
+
+def test_class_var_bare_final_qualifier() -> None:
+    result = inspect_annotation(
+        t.ClassVar,
+        annotation_source=AnnotationSource.ANY,
+    )
+
+    assert result.qualifiers == {'class_var'}
+    assert result.type is UNKNOWN
+
+    with pytest.raises(ForbiddenQualifier):
+        inspect_annotation(t.ClassVar, annotation_source=AnnotationSource.BARE)
 
 
 def test_nested_metadata_and_qualifiers() -> None:


### PR DESCRIPTION
While currently not explicitly allowed by the typing specification, `ClassVar` is allowed as a bare type qualifier. Unlike `Final`, the actual type doesn't have to be inferred from the assignment (e.g. one can use `Any`). For this reason, the `INFERRED` sentinel was renamed to `UNKNOWN`.