### PR TITLE
Add SPDX license identifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,11 @@
 [build-system]
-requires = ['hatchling']
+requires = ['hatchling>=1.27.0']
 build-backend = 'hatchling.build'
 
 [project]
 name = 'typing-inspection'
 version = '0.4.0'
+license = "MIT"
 description = 'Runtime typing introspection tools'
 authors = [
     {name = 'Victorien Plot', email = 'contact@vctrn.dev'},
@@ -23,7 +24,6 @@ classifiers = [
     'Programming Language :: Python :: 3.13',
     'Programming Language :: Python :: 3.14',
     'Typing :: Typed',
-    'License :: OSI Approved :: MIT License',
     'Intended Audience :: Developers',
     'Topic :: Software Development :: Libraries :: Python Modules',
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ build-backend = 'hatchling.build'
 name = 'typing-inspection'
 version = '0.4.0'
 license = "MIT"
+license-files = ['LICENSE']
 description = 'Runtime typing introspection tools'
 authors = [
     {name = 'Victorien Plot', email = 'contact@vctrn.dev'},


### PR DESCRIPTION
Hatchling `v1.27.0` added support for [PEP 639](https://peps.python.org/pep-0639/) license expressions.

Metadata diff
```diff
 ...
+License-Expression: MIT
 License-File: LICENSE
 ...
-Classifier: License :: OSI Approved :: MIT License
 ...
```