### PR TITLE
Add proper reference to `dataclasses.IniVar` in `AnnotationSource.DATACLASS`

### DIFF
--- a/src/typing_inspection/introspection.py
+++ b/src/typing_inspection/introspection.py
@@ -262,7 +262,7 @@ class AnnotationSource(IntEnum):
         y: InitVar[str] = 'test'
     ```
 
-    **Allowed type qualifiers:** [`ClassVar`][typing.ClassVar], [`Final`][typing.Final], [`InitVar`][dataclasses-init-only-variables].
+    **Allowed type qualifiers:** [`ClassVar`][typing.ClassVar], [`Final`][typing.Final], [`InitVar`][dataclasses.InitVar].
     """  # noqa: E501
 
     TYPED_DICT = auto()


### PR DESCRIPTION
It was recently added in the Python documentation.